### PR TITLE
Add CI to build and deploy the site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: Build and deploy
+
+on:
+  push:
+    branches: [source]
+  pull_request:
+    branches: [source]
+
+# Allow the deploy step to push the built site to the master branch.
+permissions:
+  contents: write
+
+# Don't let two deploys run over each other.
+concurrency:
+  group: deploy-master
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn run build
+
+      # Only deploy when something lands on source (i.e. a PR is merged),
+      # not on pull_request builds. The site is served from the master branch.
+      - name: Deploy to master
+        if: github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: master
+          user_name: github-actions[bot]
+          user_email: github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: yarn


### PR DESCRIPTION
There was no CI, and deploying meant running `hexo deploy` by hand. This adds a GitHub Actions workflow that:

- builds the site on every pull request to source, so a broken build is caught before it merges,
- builds and deploys to the master branch on push to source, so the site updates when a PR is merged.

The site is served from master, so the deploy step just pushes the generated `public/` there with peaceiris/actions-gh-pages. The CNAME is part of the build output, so the custom domain is kept.

Since the workflow lives in this branch, the build check below is running on this PR itself.
