### PR TITLE
Add PSConfEU 2026 "Deep dive into Mocking" talk

### DIFF
--- a/source/_posts/mocking-deep-dive-2026.md
+++ b/source/_posts/mocking-deep-dive-2026.md
@@ -1,0 +1,14 @@
+---
+title: Deep dive into Mocking - PSConfEU 2026
+date: 2026-07-02 04:00
+tags: 
+ - talk
+ - powershell
+ - pester
+categories:
+ - talk
+---
+
+PSConfEU 2026 talk where I do a technical deep dive into how mocking is implemented inside Pester - the command resolution tricks, generating mock prototypes, renaming conflicting parameters, crossing module boundaries with session state, and how mock calls are tracked.
+
+{% youtube K62JhL5wSe8 %}


### PR DESCRIPTION
Adds my latest talk to the Talks page: **Pester - deep dive into Mocking**, from PSConfEU 2026 ([YouTube](https://www.youtube.com/watch?v=K62JhL5wSe8), published 2026-07-02).

### Changes
- New post `source/_posts/mocking-deep-dive-2026.md` following the existing talk format (front-matter with `categories: talk`, tags `talk`/`powershell`/`pester`, short description, and a `{% youtube %}` embed).
- Dated `2026-07-02` so it sorts to the top of the Talks list.

### Verification
- Ran `hexo generate` locally: the post page renders with the YouTube iframe (`embed/K62JhL5wSe8`) and appears at the top of the talks index, above the previous latest talk.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>